### PR TITLE
Helm Chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ curl https://raw.githubusercontent.com/kubero-dev/ladder/main/docker-compose.yam
 docker-compose up -d
 ```
 
+### Helm
+See [README.md](/helm-chart/README.md) in helm-chart sub-directory for more information.
+
 ## Usage
 
 ### Browser

--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: ladder
+description: A helm chart to deploy kubero-dev/ladder 
+type: application
+version: "1.0"
+appVersion: "v0.0.11"

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -1,0 +1,27 @@
+# Basic Helm Chart for deployment of Ladder
+This folder contains a basic helm chart deployment for the ladder app.  
+
+# Deployment pre-reqs
+## Values
+Edit the values to your own preferences, with the only minimum requirement being `ingress.HOST` (line 19) being updated to your intended domain name.  
+
+Other variables in values.yaml can be updated as to your preferences, with details on each variable being listed in the main [README.md](https://github.com/kubero-dev/ladder/blob/e3eb866d483f521b2bfbb4bbfd642f6d3f6ee5a4/README.md) in the root of this repo.  
+
+## Defaults in K8s
+No ingress default has been specified. 
+You can set this manually by adding an annotation to the ingress.yaml - if needed.  
+For example, to use Traefik - 
+```yaml
+metadata:
+  name: ladder-ingress
+  annotations:
+    kubernetes.io/ingress.class: traefik
+```
+
+## Helm Install
+`helm install <name> <location> -n <namespace-name> --create-namespace`  
+`helm install ladder .\ladder\ -n ladder --create-namespace`  
+
+## Helm Upgrade
+`helm upgrade <name> <location> -n <namespace-name>`  
+`helm upgrade ladder .\ladder\ -n ladder`  

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -1,11 +1,11 @@
-# Basic Helm Chart for deployment of Ladder
+# Helm Chart for deployment of Ladder
 This folder contains a basic helm chart deployment for the ladder app.  
 
 # Deployment pre-reqs
 ## Values
 Edit the values to your own preferences, with the only minimum requirement being `ingress.HOST` (line 19) being updated to your intended domain name.  
 
-Other variables in values.yaml can be updated as to your preferences, with details on each variable being listed in the main [README.md](https://github.com/kubero-dev/ladder/blob/e3eb866d483f521b2bfbb4bbfd642f6d3f6ee5a4/README.md) in the root of this repo.  
+Other variables in values.yaml can be updated as to your preferences, with details on each variable being listed in the main [README.md](/README.md) in the root of this repo.  
 
 ## Defaults in K8s
 No ingress default has been specified. 

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: ladder
+  name: ladder
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ladder
+  template:
+    metadata:
+      labels:
+        app: ladder
+    spec:
+      containers:
+      - image: "{{ .Values.image.RELEASE }}"
+        imagePullPolicy: Always
+        name: ladder
+        resources:
+          limits:
+            cpu: 250m
+            memory: 128Mi
+          requests:
+            cpu: 250m
+            memory: 128Mi
+        env:
+          - name: PORT
+            value: "{{ .Values.env.PORT }}"
+          - name: PREFORK
+            value: "{{ .Values.env.PREFORK }}"
+          - name: USER_AGENT
+            value: "{{ .Values.env.USER_AGENT }}"
+          - name: X_FORWARDED_FOR
+            value: "{{ .Values.env.X_FORWARDED_FOR }}"
+          - name: USERPASS
+            value: "{{ .Values.env.USERPASS }}"
+          - name: LOG_URLS
+            value: "{{ .Values.env.LOG_URLS }}"
+          - name: DISABLE_FORM
+            value: "{{ .Values.env.DISABLE_FORM }}"
+          - name: FORM_PATH
+            value: "{{ .Values.env.FORM_PATH }}"
+          - name: RULESET
+            value: "{{ .Values.env.RULESET }}"
+          - name: EXPOSE_RULESET
+            value: "{{ .Values.env.EXPOSE_RULESET }}"
+          - name: ALLOWED_DOMAINS
+            value: "{{ .Values.env.ALLOWED_DOMAINS }}"
+          - name: ALLOWED_DOMAINS_RULESET
+            value: "{{ .Values.env.ALLOWED_DOMAINS_RULESET }}"
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30

--- a/helm-chart/templates/ingress.yaml
+++ b/helm-chart/templates/ingress.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/helm-chart/templates/ingress.yaml
+++ b/helm-chart/templates/ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ladder-ingress
+spec:
+  rules:
+  - host: "{{ .Values.ingress.HOST }}"
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: ladder-service
+            port:
+              number: {{ .Values.ingress.PORT }}

--- a/helm-chart/templates/service.yaml
+++ b/helm-chart/templates/service.yaml
@@ -1,0 +1,14 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: ladder-service
+spec:
+  type: ClusterIP
+  selector:
+    app: ladder
+  ports:
+  - name: http
+    port: {{ .Values.ingress.PORT }}
+    protocol: TCP
+    targetPort: {{ .Values.env.PORT }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -1,0 +1,20 @@
+image:
+  RELEASE: ghcr.io/kubero-dev/ladder:v0.0.11
+  
+env:
+  PORT: 8080
+  PREFORK: "false"
+  USER_AGENT: "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
+  X_FORWARDED_FOR:
+  USERPASS: ""
+  LOG_URLS: "true"
+  DISABLE_FORM: "false"
+  FORM_PATH: ""
+  RULESET: "https://raw.githubusercontent.com/kubero-dev/ladder/main/ruleset.yaml"
+  EXPOSE_RULESET: "true"
+  ALLOWED_DOMAINS: ""
+  ALLOWED_DOMAINS_RULESET: "false"
+
+ingress:
+  HOST: "ladder.domain.com"
+  PORT: 80


### PR DESCRIPTION
Hi,
I created a very quick and basic helm chart to allow ladder to be deployed to kubernetes.  
I've tested this on a k3s cluster, with traefik, works fine.  
&nbsp;  
I'm sure someone else can do a much more robust chart, but to get it off the ground....  
&nbsp;  
Only note is that the default image version (listed in values.yaml) is the current release as of today, as best practice for container deployment is to tag a specific release. In future it could be worth investigating creating a helm repo, and then version the chart along with the releases, so charts are always up-to-date as per your releases of the main container.  
&nbsp;  
Hope this helps!  
&nbsp;  
Cheers.