### PR TITLE
Enable multiple domains to apply the same rule and add rules to ruleset

### DIFF
--- a/handlers/proxy.go
+++ b/handlers/proxy.go
@@ -172,33 +172,37 @@ func applyRules(domain string, path string, body string) string {
 	}
 
 	for _, rule := range rulesSet {
-		if rule.Domain != domain {
-			continue
-		}
-		if len(rule.Paths) > 0 && !StringInSlice(path, rule.Paths) {
-			continue
-		}
-		for _, regexRule := range rule.RegexRules {
-			re := regexp.MustCompile(regexRule.Match)
-			body = re.ReplaceAllString(body, regexRule.Replace)
-		}
-		for _, injection := range rule.Injections {
-			doc, err := goquery.NewDocumentFromReader(strings.NewReader(body))
-			if err != nil {
-				log.Fatal(err)
+		// rule.Domain can be multiple domains delimited by "|"
+		domains := strings.Split(rule.Domain, "|")
+		for _, ruleDomain := range domains {
+			if ruleDomain != domain {
+				continue
 			}
-			if injection.Replace != "" {
-				doc.Find(injection.Position).ReplaceWithHtml(injection.Replace)
+			if len(rule.Paths) > 0 && !StringInSlice(path, rule.Paths) {
+				continue
 			}
-			if injection.Append != "" {
-				doc.Find(injection.Position).AppendHtml(injection.Append)
+			for _, regexRule := range rule.RegexRules {
+				re := regexp.MustCompile(regexRule.Match)
+				body = re.ReplaceAllString(body, regexRule.Replace)
 			}
-			if injection.Prepend != "" {
-				doc.Find(injection.Position).PrependHtml(injection.Prepend)
-			}
-			body, err = doc.Html()
-			if err != nil {
-				log.Fatal(err)
+			for _, injection := range rule.Injections {
+				doc, err := goquery.NewDocumentFromReader(strings.NewReader(body))
+				if err != nil {
+					log.Fatal(err)
+				}
+				if injection.Replace != "" {
+					doc.Find(injection.Position).ReplaceWithHtml(injection.Replace)
+				}
+				if injection.Append != "" {
+					doc.Find(injection.Position).AppendHtml(injection.Append)
+				}
+				if injection.Prepend != "" {
+					doc.Find(injection.Position).PrependHtml(injection.Prepend)
+				}
+				body, err = doc.Html()
+				if err != nil {
+					log.Fatal(err)
+				}
 			}
 		}
 	}

--- a/ruleset.yaml
+++ b/ruleset.yaml
@@ -120,5 +120,7 @@
           document.addEventListener("DOMContentLoaded", () => {
             let paywall = document.querySelectorAll('div[data-qa$="-ad"], div[id="leaderboard-wrapper"], div[data-qa="subscribe-promo"]');
             paywall.forEach(el => { el.remove(); });
+            const images = document.querySelectorAll('img');
+            images.forEach(image => { image.parentElement.style.filter = ''; });
           });
         </script>

--- a/ruleset.yaml
+++ b/ruleset.yaml
@@ -4,21 +4,21 @@
       replace: <script $1 script="/https://www.example.com/$3"
   injections:
     - position: head # Position where to inject the code
-      append: | 
+      append: |
         <script>
           window.localStorage.clear();
           console.log("test");
           alert("Hello!");
         </script>
     - position: h1
-      replace: | 
+      replace: |
         <h1>An example with a ladder ;-)</h1>
 - domain: www.americanbanker.com
-  paths: 
+  paths:
     - /news
   injections:
     - position: head
-      append: | 
+      append: |
         <script>
           document.addEventListener("DOMContentLoaded", () => {
             const inlineGate = document.querySelector('.inline-gate');
@@ -30,7 +30,7 @@
           });
         </script>
 - domain: www.nzz.ch
-  paths: 
+  paths:
     - /international
     - /sport
     - /wirtschaft
@@ -46,10 +46,79 @@
     - /finanze
   injections:
     - position: head
-      append: | 
+      append: |
         <script>
           document.addEventListener("DOMContentLoaded", () => {
             const paywall = document.querySelector('.dynamic-regwall');
             removeDOMElement(paywall)
+          });
+        </script>
+- domain: www.architecturaldigest.com|www.bonappetit.com|www.cntraveler.com|www.epicurious.com|www.gq.com|www.newyorker.com|www.vanityfair.com|www.vogue.com|www.wired.com
+  injections:
+    - position: head
+      append: |
+        <script>
+          document.addEventListener("DOMContentLoaded", () => {
+            const banners = document.querySelectorAll('.paywall-bar, div[class^="MessageBannerWrapper-"');
+            banners.forEach(el => { el.remove(); });
+          });
+        </script>
+- domain: www.nytimes.com|www.time.com
+  injections:
+    - position: head
+      append: |
+        <script>
+          window.localStorage.clear();
+          document.addEventListener("DOMContentLoaded", () => {
+            const banners = document.querySelectorAll('div[data-testid="inline-message"], div[id^="ad-"], div[id^="leaderboard-"], div.expanded-dock, div.pz-ad-box, div[id="top-wrapper"], div[id="bottom-wrapper"]');
+            banners.forEach(el => { el.remove(); });
+          });
+        </script>
+- domain: www.thestar.com|www.niagarafallsreview.ca|www.stcatharinesstandard.ca|www.thepeterboroughexaminer.com|www.therecord.com|www.thespec.com|www.wellandtribune.ca
+  injections:
+    - position: head
+      append: |
+        <script>
+          window.localStorage.clear();
+          document.addEventListener("DOMContentLoaded", () => {
+            const paywall = document.querySelectorAll('div.subscriber-offers');
+            paywall.forEach(el => { el.remove(); });
+            const subscriber_only = document.querySelectorAll('div.subscriber-only');
+            for (const elem of subscriber_only) {
+              if (elem.classList.contains('encrypted-content') && dompurify_loaded) {
+                const parser = new DOMParser();
+                const doc = parser.parseFromString('<div>' + DOMPurify.sanitize(unscramble(elem.innerText)) + '</div>', 'text/html');
+                const content_new = doc.querySelector('div');
+                elem.parentNode.replaceChild(content_new, elem);
+              }
+              elem.removeAttribute('style');
+              elem.removeAttribute('class');
+            }
+            const banners = document.querySelectorAll('div.subscription-required, div.redacted-overlay, div.subscriber-hide, div.tnt-ads-container');
+            banners.forEach(el => { el.remove(); });
+            const ads = document.querySelectorAll('div.tnt-ads-container, div[class*="adLabelWrapper"]');
+            ads.forEach(el => { el.remove(); });
+            const recommendations = document.querySelectorAll('div[id^="tncms-region-article"]');
+            recommendations.forEach(el => { el.remove(); });
+          });
+        </script>
+- domain: www.usatoday.com
+  injections:
+    - position: head
+      append: |
+        <script>
+          document.addEventListener("DOMContentLoaded", () => {
+            const banners = document.querySelectorAll('div.roadblock-container, .gnt_nb, [aria-label="advertisement"], div[id="main-frame-error"]');
+            banners.forEach(el => { el.remove(); });
+          });
+        </script>
+- domain: www.washingtonpost.com
+  injections:
+    - position: head
+      append: |
+        <script>
+          document.addEventListener("DOMContentLoaded", () => {
+            let paywall = document.querySelectorAll('div[data-qa$="-ad"], div[id="leaderboard-wrapper"], div[data-qa="subscribe-promo"]');
+            paywall.forEach(el => { el.remove(); });
           });
         </script>


### PR DESCRIPTION
1) Feat: allow multiple domains to use the same rule using the pipe operator as a delimiter
This PR parses `rule.Domain` and splits by the "|" delimiter. This allows you to define several related domains to apply the same injections in `ruleset.yaml`. For instance:
```yaml
- domain: www.architecturaldigest.com|www.bonappetit.com|www.cntraveler.com|www.epicurious.com|www.gq.com|www.newyorker.com|www.vanityfair.com|www.vogue.com|www.wired.com
 ```

This PR also adds rules to the ruleset for several domains.