### PR TITLE
Allow the user to specify the Content Security Policy for a domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ See in [ruleset.yaml](ruleset.yaml) for an example.
     x-forwarded-for: none      # override X-Forwarded-For header or delete with none
     referer: none              # override Referer header or delete with none
     user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36
+    content-security-policy: script-src 'self'; # override response header
     cookie: privacy=1
   regexRules:
     - match: <script\s+([^>]*\s+)?src="(/)([^"]*)"

--- a/handlers/proxy.go
+++ b/handlers/proxy.go
@@ -33,6 +33,8 @@ func ProxySite(c *fiber.Ctx) error {
 	}
 
 	c.Set("Content-Type", resp.Header.Get("Content-Type"))
+	c.Set("Content-Security-Policy", resp.Header.Get("Content-Security-Policy"))
+
 	return c.SendString(body)
 }
 
@@ -109,6 +111,10 @@ func fetchSite(urlpath string, queries map[string]string) (string, *http.Request
 	bodyB, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", nil, nil, err
+	}
+
+	if rule.Headers.CSP != "" {
+		resp.Header.Set("Content-Security-Policy", rule.Headers.CSP)
 	}
 
 	log.Print("rule", rule)

--- a/handlers/types.go
+++ b/handlers/types.go
@@ -16,6 +16,7 @@ type Rule struct {
 		XForwardedFor string `yaml:"x-forwarded-for,omitempty"`
 		Referer       string `yaml:"referer,omitempty"`
 		Cookie        string `yaml:"cookie,omitempty"`
+		CSP           string `yaml:"content-security-policy,omitempty"`
 	} `yaml:"headers,omitempty"`
 	GoogleCache bool    `yaml:"googleCache,omitempty"`
 	RegexRules  []Regex `yaml:"regexRules"`

--- a/ruleset.yaml
+++ b/ruleset.yaml
@@ -1,6 +1,6 @@
 - domain: example.com
-  domains:
-    - www.beispiel.de
+  domains: 
+  - www.beispiel.de
   googleCache: true
   headers:
     x-forwarded-for: none
@@ -61,16 +61,16 @@
             removeDOMElement(paywall)
           });
         </script>
-- domains:
-    - www.architecturaldigest.com
-    - www.bonappetit.com
-    - www.cntraveler.com
-    - www.epicurious.com
-    - www.gq.com
-    - www.newyorker.com
-    - www.vanityfair.com
-    - www.vogue.com
-    - www.wired.com
+- domains: 
+  - www.architecturaldigest.com
+  - www.bonappetit.com
+  - www.cntraveler.com
+  - www.epicurious.com
+  - www.gq.com
+  - www.newyorker.com
+  - www.vanityfair.com
+  - www.vogue.com
+  - www.wired.com
   injections:
     - position: head
       append: |
@@ -80,13 +80,13 @@
             banners.forEach(el => { el.remove(); });
           });
         </script>
-- domains:
-    - www.nytimes.com
-    - www.time.com
+- domains: 
+  - www.nytimes.com
+  - www.time.com
   headers:
     ueser-agent: Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
     cookie: nyt-a=; nyt-gdpr=0; nyt-geo=DE; nyt-privacy=1
-    referer: https://www.google.com/
+    referer: https://www.google.com/ 
   injections:
     - position: head
       append: |
@@ -97,14 +97,14 @@
             banners.forEach(el => { el.remove(); });
           });
         </script>
-- domains:
-    - www.thestar.com
-    - www.niagarafallsreview.ca
-    - www.stcatharinesstandard.ca
-    - www.thepeterboroughexaminer.com
-    - www.therecord.com
-    - www.thespec.com
-    - www.wellandtribune.ca
+- domains: 
+  - www.thestar.com
+  - www.niagarafallsreview.ca
+  - www.stcatharinesstandard.ca
+  - www.thepeterboroughexaminer.com
+  - www.therecord.com
+  - www.thespec.com
+  - www.wellandtribune.ca
   injections:
     - position: head
       append: |

--- a/ruleset.yaml
+++ b/ruleset.yaml
@@ -1,6 +1,6 @@
 - domain: example.com
-  domains: 
-  - www.beispiel.de
+  domains:
+    - www.beispiel.de
   googleCache: true
   headers:
     x-forwarded-for: none
@@ -61,16 +61,16 @@
             removeDOMElement(paywall)
           });
         </script>
-- domains: 
-  - www.architecturaldigest.com
-  - www.bonappetit.com
-  - www.cntraveler.com
-  - www.epicurious.com
-  - www.gq.com
-  - www.newyorker.com
-  - www.vanityfair.com
-  - www.vogue.com
-  - www.wired.com
+- domains:
+    - www.architecturaldigest.com
+    - www.bonappetit.com
+    - www.cntraveler.com
+    - www.epicurious.com
+    - www.gq.com
+    - www.newyorker.com
+    - www.vanityfair.com
+    - www.vogue.com
+    - www.wired.com
   injections:
     - position: head
       append: |
@@ -80,13 +80,13 @@
             banners.forEach(el => { el.remove(); });
           });
         </script>
-- domains: 
-  - www.nytimes.com
-  - www.time.com
+- domains:
+    - www.nytimes.com
+    - www.time.com
   headers:
     ueser-agent: Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
     cookie: nyt-a=; nyt-gdpr=0; nyt-geo=DE; nyt-privacy=1
-    referer: https://www.google.com/ 
+    referer: https://www.google.com/
   injections:
     - position: head
       append: |
@@ -97,14 +97,14 @@
             banners.forEach(el => { el.remove(); });
           });
         </script>
-- domains: 
-  - www.thestar.com
-  - www.niagarafallsreview.ca
-  - www.stcatharinesstandard.ca
-  - www.thepeterboroughexaminer.com
-  - www.therecord.com
-  - www.thespec.com
-  - www.wellandtribune.ca
+- domains:
+    - www.thestar.com
+    - www.niagarafallsreview.ca
+    - www.stcatharinesstandard.ca
+    - www.thepeterboroughexaminer.com
+    - www.therecord.com
+    - www.thespec.com
+    - www.wellandtribune.ca
   injections:
     - position: head
       append: |
@@ -161,4 +161,5 @@
     referer: https://t.co/x?amp=1
     x-forwarded-for: none
     user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36
-    cookie: 
+    content-security-policy: script-src 'self';
+    cookie:

--- a/ruleset.yaml
+++ b/ruleset.yaml
@@ -162,4 +162,4 @@
     x-forwarded-for: none
     user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36
     content-security-policy: script-src 'self';
-    cookie:
+    cookie: 


### PR DESCRIPTION
Since Ladder proxies requests, allowing the user to specify a Content Security Policy header can effectively limit which scripts are allowed to run in browser. 

Example:
```yaml
headers:
    referer: none
    x-forwarded-for: none
    user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36
    content-security-policy: script-src 'self';
```