### PR TITLE
update go.mod with repository path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module ladder
+module github.com/everywall/ladder
 
 go 1.21.1
 


### PR DESCRIPTION
### issue

- `go.mod` file: declared path `module ladder` does not align with repository path `github.com/everywall/ladder`
   - discrepancy makes it harder for Go modules to import `ladder` as a direct dependency

### update

- declare module path as `github.com/everywall/ladder`
   - ensure adheres to standard Go module best practices
   - avoid other projects having to require special handling or workarounds

### examples

1. `kubernetes/kubernetes`
    *   repo: `github.com/kubernetes/kubernetes`
    *   module line: `module k8s.io/kubernetes`
    *   [go.mod file](https://github.com/kubernetes/kubernetes/blob/master/go.mod)

2.  `golang/sync`
    *   repo: `github.com/golang/sync`
    *   module line: `module golang.org/x/sync`
    *   [go.mod file](https://github.com/golang/sync/blob/master/go.mod)

3.  `gin-gonic/gin`
    *   repo: `github.com/gin-gonic/gin`
    *   module line: `module github.com/gin-gonic/gin`
    *   [go.mod file](https://github.com/gin-gonic/gin/blob/master/go.mod)

### testing

This change is a metadata update to the `go.mod` file and does not alter any Go source code. Existing tests should continue to pass, as the internal package structure remains unchanged.