### PR TITLE
enable external package usage

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"strings"
 
-	"ladder/handlers"
-	"ladder/handlers/cli"
+	"github.com/everywall/ladder/handlers"
+	"github.com/everywall/ladder/handlers/cli"
 
 	"github.com/akamensky/argparse"
 	"github.com/gofiber/fiber/v2"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module ladder
+module github.com/everywall/ladder
 
 go 1.21.1
 

--- a/handlers/cli/cli.go
+++ b/handlers/cli/cli.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"os"
 
-	"ladder/pkg/ruleset"
+	"github.com/everywall/ladder/pkg/ruleset"
 
 	"golang.org/x/term"
 )

--- a/handlers/proxy.go
+++ b/handlers/proxy.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"ladder/pkg/ruleset"
+	"github.com/everywall/ladder/pkg/ruleset"
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/gofiber/fiber/v2"
@@ -105,7 +105,7 @@ func ProxySite(rulesetPath string) fiber.Handler {
 		}
 
 		queries := c.Queries()
-		body, _, resp, err := fetchSite(url, queries)
+		body, _, resp, err := FetchSite(url, queries)
 		if err != nil {
 			log.Println("ERROR:", err)
 			c.SendStatus(fiber.StatusInternalServerError)
@@ -156,7 +156,7 @@ func modifyURL(uri string, rule ruleset.Rule) (string, error) {
 	return newUrl.String(), nil
 }
 
-func fetchSite(urlpath string, queries map[string]string) (string, *http.Request, *http.Response, error) {
+func FetchSite(urlpath string, queries map[string]string) (string, *http.Request, *http.Response, error) {
 	urlQuery := "?"
 	if len(queries) > 0 {
 		for k, v := range queries {

--- a/handlers/proxy.test.go
+++ b/handlers/proxy.test.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"testing"
 
-	"ladder/pkg/ruleset"
+	"github.com/everywall/ladder/pkg/ruleset"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
This PR makes minimal changes to enable external Go packages to import and use Ladder’s proxy functionality as a proper Go module dependency, without requiring `replace` directives or code duplication.

### changes

#### 1. `handlers/proxy.go`

- renamed `fetchSite` to `FetchSite` to make core proxy function exportable
   - updated internal call to use the new function name
   - enables external packages to access full-featured proxy logic
- **note: export not possible without renaming**

#### 2. `go.mod`

- changed from `module ladder` to `module github.com/everywall/ladder`
   - follows standard practices for Go module in public repositories
   - allows for other Go modules to import `ladder` as a direct dependency
- updated internal package imports to use new module path: \
  `cmd/main.go` \
  `handlers/proxy.go` \
  `handlers/proxy.test.go` \
  `handlers/cli/cli.go`
- note: import still posible without changes using `replace` directives

### example module lines

1. `kubernetes/kubernetes`
    *   repo: `github.com/kubernetes/kubernetes`
    *   module line: `module k8s.io/kubernetes`
    *   [go.mod file](https://github.com/kubernetes/kubernetes/blob/master/go.mod)

2.  `golang/sync`
    *   repo: `github.com/golang/sync`
    *   module line: `module golang.org/x/sync`
    *   [go.mod file](https://github.com/golang/sync/blob/master/go.mod)

3.  `gin-gonic/gin`
    *   repo: `github.com/gin-gonic/gin`
    *   module line: `module github.com/gin-gonic/gin`
    *   [go.mod file](https://github.com/gin-gonic/gin/blob/master/go.mod)


### impact & testing

- minor metadata and structure changes; functional logic not modified
- eisitng tests continue to pass without modification
- internal package structure and APIs remain unchanged
