### PR TITLE
Add Australian news sites rulesets

### DIFF
--- a/rulesets/au/_multi-nine-media.yaml
+++ b/rulesets/au/_multi-nine-media.yaml
@@ -1,0 +1,38 @@
+- domains:
+  - www.smh.com.au
+  - www.theage.com.au
+  - www.brisbanetimes.com.au
+  - www.watoday.com.au
+  headers:
+    referer: https://www.google.com/
+  injections:
+    - position: head
+      append: |
+        <script>
+          window.localStorage.clear();
+          document.addEventListener("DOMContentLoaded", () => {
+            // Remove paywall overlays and banners
+            const paywallElements = document.querySelectorAll('.subscription-wall, .paywall-overlay, .premium-content-banner, .subscribe-banner, [class*="paywall"], [class*="subscription"], [id*="paywall"], [id*="subscription"]');
+            paywallElements.forEach(el => { el.remove(); });
+            
+            // Remove locked content notices
+            const lockedContent = document.querySelectorAll('[class*="locked"], [class*="premium"], [class*="subscriber-only"]');
+            lockedContent.forEach(el => {
+              el.style.display = '';
+              el.classList.remove('locked', 'premium', 'subscriber-only');
+            });
+            
+            // Unlock article content
+            const articleContent = document.querySelectorAll('article, [class*="article"], [class*="story"]');
+            articleContent.forEach(el => {
+              el.style.overflow = '';
+              el.style.maxHeight = '';
+              el.classList.remove('locked', 'truncated');
+            });
+            
+            // Remove subscription prompts
+            const subscribePrompts = document.querySelectorAll('[class*="subscribe"], [class*="sign-up"], [id*="subscribe"]');
+            subscribePrompts.forEach(el => { el.remove(); });
+          });
+        </script>
+

--- a/rulesets/au/afr-com.yaml
+++ b/rulesets/au/afr-com.yaml
@@ -1,0 +1,28 @@
+- domain: www.afr.com
+  headers:
+    referer: https://www.google.com/
+    user-agent: Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
+  injections:
+    - position: head
+      append: |
+        <script>
+          window.localStorage.clear();
+          document.addEventListener("DOMContentLoaded", () => {
+            // Remove AFR paywall elements
+            const paywall = document.querySelectorAll('.paywall, .subscription-wall, [class*="paywall"], [class*="premium"], [id*="paywall"]');
+            paywall.forEach(el => { el.remove(); });
+            
+            // Unlock article content
+            const article = document.querySelectorAll('article, [class*="article-content"], [class*="story-body"]');
+            article.forEach(el => {
+              el.style.overflow = '';
+              el.style.maxHeight = 'none';
+              el.classList.remove('locked', 'truncated', 'premium');
+            });
+            
+            // Remove subscription overlays
+            const overlays = document.querySelectorAll('.overlay, .modal, [class*="subscription"], [class*="subscribe"]');
+            overlays.forEach(el => { el.remove(); });
+          });
+        </script>
+

--- a/rulesets/au/news-com-au.yaml
+++ b/rulesets/au/news-com-au.yaml
@@ -1,0 +1,27 @@
+- domain: www.news.com.au
+  headers:
+    referer: https://www.google.com/
+  injections:
+    - position: head
+      append: |
+        <script>
+          window.localStorage.clear();
+          document.addEventListener("DOMContentLoaded", () => {
+            // Remove News.com.au paywall elements
+            const paywall = document.querySelectorAll('.paywall, .subscription-gate, [class*="paywall"], [class*="premium"], [id*="paywall"], [id*="subscription"]');
+            paywall.forEach(el => { el.remove(); });
+            
+            // Unlock article content
+            const article = document.querySelectorAll('article, [class*="article-body"], [class*="story"]');
+            article.forEach(el => {
+              el.style.overflow = '';
+              el.style.maxHeight = '';
+              el.style.display = '';
+            });
+            
+            // Remove subscription prompts and banners
+            const subscribeBanners = document.querySelectorAll('[class*="subscribe"], [class*="sign-up"], .subscription-promo');
+            subscribeBanners.forEach(el => { el.remove(); });
+          });
+        </script>
+

--- a/rulesets/au/theaustralian-com-au.yaml
+++ b/rulesets/au/theaustralian-com-au.yaml
@@ -1,0 +1,28 @@
+- domain: www.theaustralian.com.au
+  headers:
+    referer: https://www.google.com/
+    user-agent: Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
+  injections:
+    - position: head
+      append: |
+        <script>
+          window.localStorage.clear();
+          document.addEventListener("DOMContentLoaded", () => {
+            // Remove The Australian paywall
+            const paywall = document.querySelectorAll('.paywall, .subscription-wall, [class*="paywall"], [class*="premium-content"], [id*="paywall"]');
+            paywall.forEach(el => { el.remove(); });
+            
+            // Unlock article content
+            const article = document.querySelectorAll('article, [class*="article-body"], [class*="story-body"]');
+            article.forEach(el => {
+              el.style.overflow = '';
+              el.style.maxHeight = 'none';
+              el.classList.remove('locked', 'premium', 'subscriber-only');
+            });
+            
+            // Remove subscription overlays and modals
+            const overlays = document.querySelectorAll('.overlay, .modal-backdrop, [class*="subscription"], [class*="subscribe"]');
+            overlays.forEach(el => { el.remove(); });
+          });
+        </script>
+


### PR DESCRIPTION
This PR adds rulesets for major Australian news sites to bypass paywalls.

## Added Sites:
- **Nine Media Group sites** (multi-domain ruleset):
  - Sydney Morning Herald (smh.com.au)
  - The Age (theage.com.au)
  - Brisbane Times (brisbanetimes.com.au)
  - WA Today (watoday.com.au)

- **Australian Financial Review** (afr.com)
- **News.com.au** (news.com.au)
- **The Australian** (theaustralian.com.au)

## Changes:
- Created new `rulesets/au/` directory
- Added 4 YAML ruleset files with JavaScript injections to remove paywall overlays, unlock article content, and remove subscription prompts
- Rules follow the same pattern as existing rulesets and include appropriate headers (referer, user-agent) where needed

The rulesets use DOM manipulation to remove paywall elements and unlock content, following the same approach used in other country-specific rulesets.