### PR TITLE
fix: encode URL client-side to prevent double-slash normalization

### DIFF
--- a/handlers/form.html
+++ b/handlers/form.html
@@ -42,6 +42,11 @@
             if (url.indexOf('http') === -1) {
                 url = 'https://' + url;
             }
+            try {
+                url = encodeURIComponent(decodeURIComponent(url));
+            } catch (e) {
+                url = encodeURIComponent(url);
+            }
             window.location.href = window.location.pathname.replace(/\/$/, '') + '/' + url;
             return false;
         });


### PR DESCRIPTION
## Fix: encode target URL client-side to prevent double-slash normalization

Closes #75

### Problem
When a user submits a URL through the web UI, the form navigates to `/<target_url>` as a raw path. Browsers and reverse proxies (nginx, Traefik, Apache) normalize `//` in paths per RFC 3986, collapsing `https://` to `https:/`. By the time the request reaches Ladder, the hostname is gone and it errors with `http: no Host in request URL`.

The existing workarounds (nginx `merge_slashes off`, Traefik `sanitizePath: false`, pinning Traefik to v3.3.5) are fragile and proxy-specific.

### Fix
Encode the target URL with `encodeURIComponent` in the submit handler before navigation, so the browser never sees a raw `://` in the path. `decodeURIComponent` is applied first to avoid double-encoding URLs that are already partially encoded (e.g. containing `%20`). A try/catch handles the edge case of malformed percent sequences.

```js
try {
    url = encodeURIComponent(decodeURIComponent(url));
} catch (e) {
    url = encodeURIComponent(url);
}
```

This fix is proxy-agnostic and requires no configuration changes on the server side.